### PR TITLE
fix(docker): build backend from workspace root

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,7 +62,8 @@ jobs:
       - name: Build and push backend Docker image
         uses: docker/build-push-action@v6
         with:
-          context: ./backend
+          context: .
+          file: backend/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-backend.outputs.tags }}
           labels: ${{ steps.meta-backend.outputs.labels }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,25 +8,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy manifests first for dependency caching
+# Copy workspace manifests first for dependency caching
 COPY Cargo.toml Cargo.lock ./
+COPY backend/Cargo.toml ./backend/
 
 # Create dummy src to build dependencies
-RUN mkdir src && \
-    echo "fn main() {}" > src/main.rs
+RUN mkdir -p backend/src && \
+    echo "fn main() {}" > backend/src/main.rs
 
 # Build dependencies only
-RUN cargo build --release && \
-    rm -rf src
+RUN cargo build --release -p babel && \
+    rm -rf backend/src
 
 # Copy actual source code
-COPY src ./src
+COPY backend/src ./backend/src
 
 # Touch source files to ensure rebuild
-RUN touch src/main.rs
+RUN touch backend/src/main.rs
 
 # Build the application
-RUN cargo build --release
+RUN cargo build --release -p babel
 
 # Runtime stage
 FROM docker.io/debian:bookworm-slim
@@ -42,7 +43,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=builder /app/target/release/babel /app/babel
 
 # Copy config files if needed
-COPY filter_config.json ./
+COPY backend/filter_config.json ./
 
 # Expose the default port
 EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,8 @@ services:
 
   backend:
     build:
-      context: ./backend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: backend/Dockerfile
     container_name: babel-backend
     ports:
       - "3000:3000"


### PR DESCRIPTION
Update Dockerfile to use workspace root context for access to Cargo.lock. This fixes the build after removing the duplicate Cargo.lock from backend/.