### PR TITLE
refactor(backend): move censorship replacement to const

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,7 +17,6 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/babel /app/babel
-COPY backend/filter_config.json ./
 COPY backend/words.json ./
 EXPOSE 3000
 CMD ["./babel"]

--- a/backend/src/data.rs
+++ b/backend/src/data.rs
@@ -11,6 +11,9 @@ pub type Timestamp = u64;
 
 pub const MAX_USER_ACTIONS: usize = 100;
 
+/// The replacement string used when censoring banned words.
+pub const CENSORSHIP_REPLACEMENT: &str = "***";
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Message {
     pub id: MessageId,
@@ -64,19 +67,9 @@ pub struct RoomUpdate {
     pub room_closed: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct FilterConfig {
     pub banned_words: HashMap<CountryCode, Vec<String>>,
-    pub replacement: String,
-}
-
-impl Default for FilterConfig {
-    fn default() -> Self {
-        Self {
-            banned_words: HashMap::new(),
-            replacement: "***".to_string(),
-        }
-    }
 }
 
 pub trait RoomConfig: Send + Sync {

--- a/backend/src/filter.rs
+++ b/backend/src/filter.rs
@@ -1,4 +1,4 @@
-use crate::data::{CountryCode, FilterConfig};
+use crate::data::{CountryCode, FilterConfig, CENSORSHIP_REPLACEMENT};
 
 pub struct CensorshipFilter {
     pub(crate) config: &'static FilterConfig,
@@ -55,7 +55,7 @@ impl CensorshipFilter {
 
         for (start, _) in lower_content.match_indices(&lower_word) {
             result.push_str(&content[last_end..start]);
-            result.push_str(&self.config.replacement);
+            result.push_str(CENSORSHIP_REPLACEMENT);
             last_end = start + word.len();
         }
         result.push_str(&content[last_end..]);
@@ -74,10 +74,7 @@ mod tests {
         banned_words.insert("A".to_string(), vec!["bad".to_string(), "evil".to_string()]);
         banned_words.insert("B".to_string(), vec!["wrong".to_string()]);
 
-        FilterConfig {
-            banned_words,
-            replacement: "***".to_string(),
-        }
+        FilterConfig { banned_words }
     }
 
     #[test]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,23 +2,14 @@ use babel::data::*;
 use babel::manager::RoomManager;
 use babel::room::ChatRoom;
 use babel::server::{AppState, build_router};
-use babel::utils::deserialize_from_file;
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
-use serde::Deserialize;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-static FILTER_CONFIG: Lazy<FilterConfig> =
-    Lazy::new(|| deserialize_from_file("filter_config.json"));
-
-#[derive(Deserialize)]
-struct UserToken {
-    user_id: String,
-    country: String,
-}
+static FILTER_CONFIG: Lazy<FilterConfig> = Lazy::new(FilterConfig::default);
 
 pub struct DefaultRoomConfig;
 

--- a/backend/src/room.rs
+++ b/backend/src/room.rs
@@ -335,10 +335,7 @@ mod tests {
         let mut banned_words = HashMap::new();
         banned_words.insert("A".to_string(), vec!["freedom".to_string()]);
         banned_words.insert("B".to_string(), vec!["monarchy".to_string()]);
-        Box::leak(Box::new(FilterConfig {
-            banned_words,
-            replacement: "***".to_string(),
-        }))
+        Box::leak(Box::new(FilterConfig { banned_words }))
     }
 
     #[test]


### PR DESCRIPTION
- Add CENSORSHIP_REPLACEMENT const in data.rs
- Remove replacement field from FilterConfig
- Use default FilterConfig instead of loading from file
- Remove filter_config.json from Dockerfile

The filter_config.json file is no longer needed as banned words are dynamically generated from words.json per room.