### PR TITLE
fix(backend): implement comprehensive message censorship for receivers

### DIFF
--- a/backend/src/data.rs
+++ b/backend/src/data.rs
@@ -62,7 +62,8 @@ pub struct Notification {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RoomUpdate {
     pub room_state: RoomState,
-    pub new_messages: Vec<CensoredMessage>,
+    /// Raw messages that need to be censored per-user before sending to clients.
+    pub new_messages: Vec<Message>,
     pub notifications: Vec<Notification>,
     pub room_closed: bool,
 }

--- a/backend/src/room.rs
+++ b/backend/src/room.rs
@@ -60,7 +60,7 @@ impl ChatRoom {
     pub fn new(room_id: RoomId, config: &'static FilterConfig) -> Self {
         // Load words from words.json
         let words = load_words("words.json");
-        let country_codes = ["TW", "CN", "US", "RU"];
+        let country_codes = ["A", "B", "C", "D"];
         let (allowed_words, banned_map) = generate_allowed_and_banned_words(&words, &country_codes);
         // Clone and update the config's banned_words for this room
         let mut config_owned = config.clone();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     environment:
       - RUST_ENV=production
       - PORT=3000
-      - RUST_LOG=info
+      - RUST_LOG=bable=trace,debug
     networks:
       - babel-network
     restart: unless-stopped


### PR DESCRIPTION
- Update RoomConnector to include censorship and shadow ban flags
- Implement sender/receiver censorship and shadow ban logic in server
- Broadcast raw messages to let server apply per-user censorship
- Add unit tests for per-country message censorship in server.rs
- Fix WebSocket message type naming collision in server.rs
- Update logging configuration in docker-compose.yml