### PR TITLE
fix(backend): Replace Box::leak with Arc<FilterConfig>

### DIFF
--- a/backend/src/data.rs
+++ b/backend/src/data.rs
@@ -168,7 +168,7 @@ pub trait Room: Send + Sync {
 }
 
 pub trait RoomConfig: Send + Sync {
-    fn get_filter_config(&self) -> &'static FilterConfig;
+    fn get_filter_config(&self) -> &FilterConfig;
     fn init_room(&self, room_id: RoomId) -> Box<dyn Room>;
 }
 

--- a/backend/src/filter.rs
+++ b/backend/src/filter.rs
@@ -1,11 +1,13 @@
+use std::sync::Arc;
+
 use crate::data::{CENSORSHIP_REPLACEMENT, CountryCode, FilterConfig};
 
 pub struct CensorshipFilter {
-    pub(crate) config: &'static FilterConfig,
+    pub(crate) config: Arc<FilterConfig>,
 }
 
 impl CensorshipFilter {
-    pub fn new(config: &'static FilterConfig) -> Self {
+    pub fn new(config: Arc<FilterConfig>) -> Self {
         Self { config }
     }
 
@@ -75,17 +77,17 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    fn make_config() -> FilterConfig {
+    fn make_config() -> Arc<FilterConfig> {
         let mut banned_words = HashMap::new();
         banned_words.insert("A".to_string(), vec!["bad".to_string(), "evil".to_string()]);
         banned_words.insert("B".to_string(), vec!["wrong".to_string()]);
 
-        FilterConfig { banned_words }
+        Arc::new(FilterConfig { banned_words })
     }
 
     #[test]
     fn test_censor_sender_words() {
-        let config = Box::leak(Box::new(make_config()));
+        let config = make_config();
         let filter = CensorshipFilter::new(config);
 
         let sender = "A".to_string();
@@ -98,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_censor_receiver_words() {
-        let config = Box::leak(Box::new(make_config()));
+        let config = make_config();
         let filter = CensorshipFilter::new(config);
 
         let sender = "C".to_string();
@@ -111,7 +113,7 @@ mod tests {
 
     #[test]
     fn test_censor_both_filters() {
-        let config = Box::leak(Box::new(make_config()));
+        let config = make_config();
         let filter = CensorshipFilter::new(config);
 
         let sender = "A".to_string();
@@ -124,7 +126,7 @@ mod tests {
 
     #[test]
     fn test_no_censorship() {
-        let config = Box::leak(Box::new(make_config()));
+        let config = make_config();
         let filter = CensorshipFilter::new(config);
 
         let sender = "A".to_string();

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -14,7 +14,7 @@ static FILTER_CONFIG: Lazy<FilterConfig> = Lazy::new(FilterConfig::default);
 pub struct DefaultRoomConfig;
 
 impl RoomConfig for DefaultRoomConfig {
-    fn get_filter_config(&self) -> &'static FilterConfig {
+    fn get_filter_config(&self) -> &FilterConfig {
         &FILTER_CONFIG
     }
 

--- a/backend/src/manager.rs
+++ b/backend/src/manager.rs
@@ -127,7 +127,7 @@ impl RoomManager {
         })
     }
 
-    pub fn get_filter_config(&self) -> &'static FilterConfig {
+    pub fn get_filter_config(&self) -> &FilterConfig {
         self.config.get_filter_config()
     }
 

--- a/backend/src/room.rs
+++ b/backend/src/room.rs
@@ -36,7 +36,7 @@ pub struct ChatRoom {
 }
 
 impl ChatRoom {
-    pub fn new(room_id: RoomId, config: &'static FilterConfig) -> Self {
+    pub fn new(room_id: RoomId, config: &FilterConfig) -> Self {
         let game = CensorshipGame::new(config);
 
         // Create initial game instructions message
@@ -508,17 +508,17 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    fn make_test_config() -> &'static FilterConfig {
+    fn make_test_config() -> FilterConfig {
         let mut banned_words = HashMap::new();
         banned_words.insert("A".to_string(), vec!["freedom".to_string()]);
         banned_words.insert("B".to_string(), vec!["monarchy".to_string()]);
-        Box::leak(Box::new(FilterConfig { banned_words }))
+        FilterConfig { banned_words }
     }
 
     #[test]
     fn test_send_note_generates_notification() {
         let config = make_test_config();
-        let mut room = ChatRoom::new("test_room".to_string(), config);
+        let mut room = ChatRoom::new("test_room".to_string(), &config);
 
         let user_id = "alice".to_string();
         let country = "A".to_string();
@@ -554,7 +554,7 @@ mod tests {
     #[test]
     fn test_send_note_empty_map() {
         let config = make_test_config();
-        let mut room = ChatRoom::new("test_room".to_string(), config);
+        let mut room = ChatRoom::new("test_room".to_string(), &config);
 
         let user_id = "bob".to_string();
         let country = "B".to_string();
@@ -578,7 +578,7 @@ mod tests {
     #[test]
     fn test_send_note_single_country() {
         let config = make_test_config();
-        let mut room = ChatRoom::new("test_room".to_string(), config);
+        let mut room = ChatRoom::new("test_room".to_string(), &config);
 
         let user_id = "charlie".to_string();
         let country = "C".to_string();
@@ -608,7 +608,7 @@ mod tests {
     #[test]
     fn test_send_note_single_word() {
         let config = make_test_config();
-        let mut room = ChatRoom::new("test_room".to_string(), config);
+        let mut room = ChatRoom::new("test_room".to_string(), &config);
 
         let user_id = "diana".to_string();
         let country = "D".to_string();
@@ -631,7 +631,7 @@ mod tests {
     #[test]
     fn test_send_note_updates_latest() {
         let config = make_test_config();
-        let mut room = ChatRoom::new("test_room".to_string(), config);
+        let mut room = ChatRoom::new("test_room".to_string(), &config);
 
         let user_id = "alice".to_string();
         let country = "A".to_string();
@@ -667,7 +667,7 @@ mod tests {
     #[test]
     fn test_system_action_send_message() {
         let config = make_test_config();
-        let mut room = ChatRoom::new("test_room".to_string(), config);
+        let mut room = ChatRoom::new("test_room".to_string(), &config);
 
         let user_id = "alice".to_string();
         let country = "A".to_string();
@@ -687,7 +687,7 @@ mod tests {
     #[test]
     fn test_system_action_send_message_array() {
         let config = make_test_config();
-        let mut room = ChatRoom::new("test_room".to_string(), config);
+        let mut room = ChatRoom::new("test_room".to_string(), &config);
 
         let user_id = "bob".to_string();
         let country = "B".to_string();
@@ -710,7 +710,7 @@ mod tests {
     #[test]
     fn test_system_action_leave_room() {
         let config = make_test_config();
-        let mut room = ChatRoom::new("test_room".to_string(), config);
+        let mut room = ChatRoom::new("test_room".to_string(), &config);
 
         let user_id = "charlie".to_string();
         let country = "C".to_string();
@@ -733,7 +733,7 @@ mod tests {
     #[test]
     fn test_game_action_submit_notes() {
         let config = make_test_config();
-        let mut room = ChatRoom::new("test_room".to_string(), config);
+        let mut room = ChatRoom::new("test_room".to_string(), &config);
 
         let user_id = "diana".to_string();
         let country = "D".to_string();
@@ -764,7 +764,7 @@ mod tests {
     #[test]
     fn test_legacy_actions_still_work() {
         let config = make_test_config();
-        let mut room = ChatRoom::new("test_room".to_string(), config);
+        let mut room = ChatRoom::new("test_room".to_string(), &config);
 
         let user_id = "eve".to_string();
         let country = "E".to_string();


### PR DESCRIPTION
## Summary

- Replace `Box::leak()` with `Arc<FilterConfig>` to eliminate memory leaks in the backend
- Previously, `CensorshipGame::new()` and test helpers used `Box::leak()` to create static references, permanently leaking memory
- This was especially problematic in test scenarios where multiple configs were created

## Changes

- `CensorshipFilter` now uses `Arc<FilterConfig>` instead of `&'static FilterConfig`
- `CensorshipGame` stores `Arc<FilterConfig>` and creates it internally from `&FilterConfig`
- Updated `RoomConfig` trait to return `&FilterConfig` instead of `&'static FilterConfig`
- Updated all tests to use `Arc::new()` instead of `Box::leak()`

## Test plan

- [x] All 20 existing tests pass
- [x] No clippy warnings
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.ai/code)